### PR TITLE
Add tooltip to the installAsModCheckbox

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/hypercubemc/iris_installer/Installer.java
+++ b/src/main/java/net/hypercubemc/iris_installer/Installer.java
@@ -176,7 +176,7 @@ public class Installer {
 
         installAsModCheckbox = new JCheckBox("Install as Fabric Mod", false);
         installAsModCheckbox.setToolTipText("If this box is checked, Iris will be installed to your mods \n folder," +
-                        "allowing you to use Iris with other fabric mods!");
+                        "allowing you to use Iris with other Fabric mods!");
         installAsModCheckbox.setHorizontalTextPosition(SwingConstants.LEFT);
         installAsModCheckbox.setAlignmentX(Component.CENTER_ALIGNMENT);
         installAsModCheckbox.addActionListener(e -> {

--- a/src/main/java/net/hypercubemc/iris_installer/Installer.java
+++ b/src/main/java/net/hypercubemc/iris_installer/Installer.java
@@ -175,6 +175,8 @@ public class Installer {
         installDirectoryPanel.add(installDirectoryPicker);
 
         installAsModCheckbox = new JCheckBox("Install as Fabric Mod", false);
+        installAsModCheckbox.setToolTipText("If this box is checked, Iris will be installed to your mods \n folder," +
+                        "allowing you to use Iris with other fabric mods!");
         installAsModCheckbox.setHorizontalTextPosition(SwingConstants.LEFT);
         installAsModCheckbox.setAlignmentX(Component.CENTER_ALIGNMENT);
         installAsModCheckbox.addActionListener(e -> {


### PR DESCRIPTION
I feel this is a good idea, to add a tooltip to the `installAsModCheckbox` to reduce the amount of people coming into the support channels asking how to install Iris with other mods. 
*excuse the screenshot quality, janky stuff happened*
![image](https://user-images.githubusercontent.com/67918617/128168082-259586c7-d033-45ce-9927-6fce4cf1e1e4.png)
