### PR TITLE
Add breaking update checker

### DIFF
--- a/src/main/java/net/hypercubemc/iris_installer/Installer.java
+++ b/src/main/java/net/hypercubemc/iris_installer/Installer.java
@@ -387,7 +387,7 @@ public class Installer {
             try {
                 Desktop.getDesktop().browse(new URI("https://irisshaders.net/download"));
             } catch (Exception e2) { // Should never happen, but let's handle it, why not, just in case
-                JOptionPane.showMessageDialog(frame, "errrrr... This is ankward... Browser didn't launch. "
+                JOptionPane.showMessageDialog(frame, "errrrr... This is awkward... Browser didn't launch. "
                         + "\nGo to https://irisshaders.net/download to get the latest installer", "Failed to open browser", JOptionPane.ERROR_MESSAGE);
                 e2.printStackTrace();
             }

--- a/src/main/java/net/hypercubemc/iris_installer/Installer.java
+++ b/src/main/java/net/hypercubemc/iris_installer/Installer.java
@@ -25,10 +25,11 @@ import java.util.zip.ZipInputStream;
 
 public class Installer {
     private static final int BREAKING_VERSION_NUMBER = 1;
+    public static final String BASE_FILES_URL = "https://raw.githubusercontent.com/IrisShaders/Iris-Installer-Files/master/";
+    public static final String BASE_MAVEN_URL = "https://raw.githubusercontent.com/IrisShaders/Iris-Installer-Maven/master/";
     InstallerMeta INSTALLER_META;
     List<InstallerMeta.Edition> EDITIONS;
     List<String> GAME_VERSIONS;
-    String BASE_URL = "https://raw.githubusercontent.com/IrisShaders/Iris-Installer-Files/master/";
 
     String selectedEditionName;
     String selectedEditionDisplayName;
@@ -73,7 +74,7 @@ public class Installer {
             return;
         }
 
-        INSTALLER_META = new InstallerMeta(BASE_URL + "meta.json");
+        INSTALLER_META = new InstallerMeta(BASE_FILES_URL + "meta.json");
         try {
             INSTALLER_META.load();
         } catch (IOException e) {
@@ -209,7 +210,7 @@ public class Installer {
             String loaderName = installAsMod ? "fabric-loader" : "iris-fabric-loader";
 
             try {
-                URL loaderVersionUrl = new URL("https://raw.githubusercontent.com/IrisShaders/Iris-Installer-Maven/master/latest-loader");
+                URL loaderVersionUrl = new URL(BASE_MAVEN_URL + "latest-loader");
                 String loaderVersion = installAsMod ? Main.LOADER_META.getLatestVersion(false).getVersion() : Utils.readTextFile(loaderVersionUrl);
                 boolean success = VanillaLauncherIntegration.installToLauncher(getVanillaGameDir(), getInstallDir(), installAsMod ? "Fabric Loader " + selectedVersion : selectedEditionDisplayName, selectedVersion, loaderName, loaderVersion, installAsMod ? VanillaLauncherIntegration.Icon.FABRIC: VanillaLauncherIntegration.Icon.IRIS);
                 if (!success) {
@@ -358,7 +359,7 @@ public class Installer {
         frame.getContentPane().add(bottomPanel, BorderLayout.SOUTH);
         
         try {
-            Json versionInfo = Json.read(new URL("https://raw.githubusercontent.com/IrisShaders/Iris-Installer-Maven/master/installer-versions.json"));
+            Json versionInfo = Json.read(new URL(BASE_MAVEN_URL + "installer-versions.json"));
             if (versionInfo.asJsonMap().get("lastBreakingId").asInteger() > BREAKING_VERSION_NUMBER) {
                 invalidVersionError(frame, "Outdated Installer", "You are running an outdated Iris Installer version that can no longer install Iris.", false);
                 System.exit(0);

--- a/src/main/java/net/hypercubemc/iris_installer/Installer.java
+++ b/src/main/java/net/hypercubemc/iris_installer/Installer.java
@@ -366,7 +366,7 @@ public class Installer {
         } catch (Exception e) {
             System.err.println("Failed to check for updates!");
             e.printStackTrace();
-            invalidVersionError(frame, "Update check failed", "Unable to check for installer updates. The installation may fail, you should try downloading it again.", true);
+            invalidVersionError(frame, "Update check failed", "Unable to check for installer updates. The installation may fail, you should try downloading the installer again.", true);
         }
 
         frame.setVisible(true);

--- a/src/main/java/net/hypercubemc/iris_installer/VanillaLauncherIntegration.java
+++ b/src/main/java/net/hypercubemc/iris_installer/VanillaLauncherIntegration.java
@@ -61,7 +61,7 @@ public class VanillaLauncherIntegration {
             String name = entry.asJsonMap().get("name").asString();
             if (name.startsWith("net.fabricmc:fabric-loader:")) {
                 entry.asJsonMap().put("name", factory.string("net.coderbot:iris-loader:" + name.substring(id.length())));
-                entry.asJsonMap().put("url", factory.string("https://raw.githubusercontent.com/IrisShaders/Iris-Installer-Maven/master/"));
+                entry.asJsonMap().put("url", factory.string(Installer.BASE_MAVEN_URL));
             }
         }
     }


### PR DESCRIPTION
This only checks for a number that should be incremented when breaking changes happen, not supposed to be used for minor updates.

Requires this file in installer-maven (not PRing since I broke my fork with loader tests):

https://github.com/altrisi/Iris-Installer-Maven/blob/master/installer-versions.json